### PR TITLE
timedropper.js: input.val() time is considered

### DIFF
--- a/timedropper.js
+++ b/timedropper.js
@@ -56,6 +56,61 @@
                 return (usePound ? "#" : "") + (g | (b << 8) | (r << 16)).toString(16);
 
             };
+            
+            var _td_setTime = function() {
+                var
+                    d = new Date(),
+                    _td_span_h = _td_c.find('.td-time span:first'),
+                    _td_span_m = _td_c.find('.td-time span:last'),
+                    h,
+                    m,
+                    reg,
+                    am,
+                    st;
+
+                if (_td_input.val().length && !_td_options.setCurrentTime) {
+
+                    reg = /\d+/g;
+                    st = _td_input.val().split(':');
+
+                    if (st) {
+
+                        h = st[0].match(reg)[0];
+                        m = st[1].match(reg)[0];
+                        if (_td_input.val().indexOf("am") != -1 || _td_input.val().indexOf("AM") != -1 || _td_input.val().indexOf("pm") != -1 || _td_input.val().indexOf("PM") != -1) {
+                            if (_td_input.val().indexOf("am") != -1 || _td_input.val().indexOf("AM") != -1) am = true;
+                            else am = false;
+
+                            if (!am) {
+                                if (h < 13) {
+                                    h = parseInt(h) + 12;
+                                    if (h == 24) h = 0;
+                                }
+                            } else if (h == 12) h = 0;
+                        } else if (h == 24) h = 0;
+                    } else {
+
+                        if (!parseInt(_td_span_h.text())) h = _td_num(d.getHours());
+                        else h = _td_num(_td_span_h.text());
+                        if (!parseInt(_td_span_m.text())) m = _td_num(d.getMinutes());
+                        else m = _td_num(_td_span_m.text());
+
+                    }
+
+                } else {
+
+                    if (!parseInt(_td_span_h.text())) h = _td_num(d.getHours());
+                    else h = _td_num(_td_span_h.text());
+                    if (!parseInt(_td_span_m.text())) m = _td_num(d.getMinutes());
+                    else m = _td_num(_td_span_m.text());
+
+                }
+
+                _td_span_h.attr('data-id', h).text(h);
+                _td_span_m.attr('data-id', m).text(m);
+
+                return {h: h, m: m};
+            };
 
             _td_input.prop({
                 'readonly': true
@@ -303,67 +358,19 @@
 
             });
 
-            var _td_init = function(value) {
+            var _td_init = function() {
 
-                var
-                    d = new Date(),
-                    _td_span_h = _td_c.find('.td-time span:first'),
-                    _td_span_m = _td_c.find('.td-time span:last'),
-                    h,
-                    m;
-
-                if (_td_input.val().length && !_td_options.setCurrentTime) {
-
-                    var reg = /\d+/g,
-                        am;
-                    var st = _td_input.val().split(':');
-
-                    if (st) {
-
-                        h = st[0].match(reg);
-                        m = st[1].match(reg);
-                        if (_td_input.val().indexOf("am") != -1 || _td_input.val().indexOf("AM") != -1 || _td_input.val().indexOf("pm") != -1 || _td_input.val().indexOf("PM") != -1) {
-                            if (_td_input.val().indexOf("am") != -1 || _td_input.val().indexOf("AM") != -1) am = true;
-                            else am = false;
-
-                            if (!am) {
-                                if (h < 13) {
-                                    h = parseInt(h) + 12;
-                                    if (h == 24) h = 0;
-                                }
-                            } else if (h == 12) h = 0;
-                        } else if (h == 24) h = 0;
-                    } else {
-
-                        if (!parseInt(_td_span_h.text())) h = _td_num(d.getHours());
-                        else h = _td_num(_td_span_h.text());
-                        if (!parseInt(_td_span_m.text())) m = _td_num(d.getMinutes());
-                        else m = _td_num(_td_span_m.text());
-
-                    }
-
-                } else {
-
-                    if (!parseInt(_td_span_h.text())) h = _td_num(d.getHours());
-                    else h = _td_num(_td_span_h.text());
-                    if (!parseInt(_td_span_m.text())) m = _td_num(d.getMinutes());
-                    else m = _td_num(_td_span_m.text());
-
-                }
-
-                _td_span_h.attr('data-id', h).text(h);
-                _td_span_m.attr('data-id', m).text(m);
-
-                _td_event_deg = Math.round((h * 360 / 23));
-
-                _td_c.find('.td-lancette div:first').css('transform', 'rotate(' + Math.round((m * 360 / 59)) + 'deg)');
+                var oTime = _td_setTime();
+                
+                _td_event_deg = Math.round((oTime.h * 360 / 23));
+                
+                _td_c.find('.td-lancette div:first').css('transform', 'rotate(' + Math.round((oTime.m * 360 / 59)) + 'deg)');
 
                 _td_rotation(_td_event_deg);
                 _td_wheel_deg = _td_event_deg;
                 _td_init_deg = -1;
 
-
-            }
+            };
 
             _td_init();
 
@@ -376,6 +383,10 @@
 
                 clearInterval(_td_event);
 
+                _td_setTime();
+                
+                $('.td-time span:last', _td_c).triggerHandler('click'); // quietly set minutes rotation
+                
                 _td_container.removeClass('td-fadeout');
                 _td_container.addClass('td-show').addClass('td-' + _td_options.init_animation);
                 _td_c.css({
@@ -383,6 +394,8 @@
                     'left': (_td_input.offset().left + (_td_input.outerWidth() / 2)) - (_td_c.outerWidth() / 2)
                 });
 
+                $('.td-time span:first', _td_c).triggerHandler('click'); // visually set hours rotation
+                
                 if (_td_c.hasClass('td-init')) {
 
                     _td_alert = setInterval(function() {


### PR DESCRIPTION
on each opening of the UI (the timedropper UI interface) - caused by clicking on the input - the timedropper internal time is reset - either to currentTime (if that option is true) or to the time found in the input.val(); this is helpful for there exist possible cases where the interface is closed and then reopened after some minutes have passed, or even after a consuming widget has updated the time in the input.val()